### PR TITLE
Use doPrivileged() for getUserModel to fetch references.

### DIFF
--- a/src/main/java/org/nuxeo/shibboleth/invitation/ShibbolethUserMapper.java
+++ b/src/main/java/org/nuxeo/shibboleth/invitation/ShibbolethUserMapper.java
@@ -102,7 +102,7 @@ public class ShibbolethUserMapper implements UserMapper {
             DocumentModel finalUserDoc = userDoc; // Effectively final
             TransactionHelper.runInTransaction(() -> updateACP(userName, email, finalUserDoc));
         } else {
-            userDoc = userManager.getUserModel(userName);
+            userDoc = Framework.doPrivileged(() -> userManager.getUserModel(userName));
         }
         if (userDoc == null) {
             userDoc = createUser(userInfo);


### PR DESCRIPTION
Without this, the [`getUserModel()`](https://github.com/nuxeo/nuxeo-shibboleth-invitation/blob/release-9.10-HF21/src/main/java/org/nuxeo/shibboleth/invitation/ShibbolethUserMapper.java#L105) function in `getOrCreateAndUpdateNuxeoPrincipal` fails to retrieve existing user, and we then fallback to the user creation code which fails because the user already exists.
This bug was introduced by commit d16b875395e422fae2cd76368659c81b4296468e when the `findUser()` function (which use [`doPrivileged`](https://github.com/nuxeo/nuxeo-shibboleth-invitation/blob/release-9.10-HF21/src/main/java/org/nuxeo/shibboleth/invitation/ShibbolethUserMapper.java#L192) for search) was replaced by a simple `getUserModel()` without a doPrivileged.

I tested it on 9.10, but it might also apply to other versions.